### PR TITLE
Fixes typo in IO/Thread part

### DIFF
--- a/notebooks/IOandThreads.ipynb
+++ b/notebooks/IOandThreads.ipynb
@@ -157,7 +157,7 @@
     "\n",
     "Erzeugen eines File Objekts\n",
     "```java\n",
-    "\tFile myfile = new File(“/some/path/to/a/file”); \t\t\n",
+    "\tFile myfile = new File("/some/path/to/a/file"); \t\t\n",
     "```\n",
     "\n",
     "Abfragen des Pfads:\n",
@@ -239,7 +239,7 @@
     "Einfaches Rezept zum Erzeugen eines Threads\n",
     "\n",
     "1. Eigene Klasse von  java.lang.Thread ableiten.\n",
-    "2. Eigenen Kode in die  run() Methode  schreiben.\n",
+    "2. Eigenen Code in die  run() Methode  schreiben.\n",
     "3. Thread mit der  start() Methode starten."
    ]
   },


### PR DESCRIPTION
Changes the quotes in the example
    new File("/some/path/to/a/file");